### PR TITLE
Apply ldap owner for /var/lib/ldap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Fanday Dai "fandaydai@live.cn"
 RUN yum -y update
 RUN yum -y install wget openldap-servers openldap-clients python-setuptools
 RUN cp /usr/share/openldap-servers/DB_CONFIG.example /var/lib/ldap/DB_CONFIG
-RUN chown ldap. /var/lib/ldap/DB_CONFIG
+RUN chown -R ldap:ldap /var/lib/ldap
 ADD files /files
 RUN chmod 0755 /files/configure.sh
 RUN /bin/bash -l -c '/files/configure.sh'


### PR DESCRIPTION
I get errors like:

``` bash
[root@c8e43afa1b2d /]# /etc/rc.d/init.d/slapd restart
Stopping slapd:                                            [FAILED]
Checking configuration files for slapd:                    [FAILED]
55aa8f73 olcDbDirectory: value #0: invalid path: Permission denied
55aa8f73 config error processing olcDatabase={2}bdb,cn=config: olcDbDirectory: value #0: invalid path: Permission denied
slaptest: bad configuration file!
```

Apply owner for ldap folder solves it.
